### PR TITLE
feat(relationship): 친구 추가 요청 기능 구현

### DIFF
--- a/src/main/java/com/example/newsfeed/relationship/RelationshipController.java
+++ b/src/main/java/com/example/newsfeed/relationship/RelationshipController.java
@@ -1,0 +1,98 @@
+package com.example.newsfeed.relationship;
+
+import com.example.newsfeed.relationship.dto.FriendRequestResponseDto;
+import com.example.newsfeed.relationship.entity.Relationship;
+import com.example.newsfeed.relationship.service.RelationshipService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class RelationshipController {
+
+    private final RelationshipService relationshipService;
+
+    // 친구 추가 요청
+    @PostMapping("/follows/{receiverId}/request")
+    public ResponseEntity<FriendRequestResponseDto> sendFriendRequest(
+            @PathVariable Long receiverId
+    ) {
+        FriendRequestResponseDto response = relationshipService.sendFriendRequest(receiverId);
+        return ResponseEntity.ok(response);
+    }
+
+    // 친구 추가 요청 수락
+    @PostMapping("/follows/{relationshipId}/accept")
+    public ResponseEntity<Relationship> acceptFriendRequest(
+            @PathVariable Long relationshipId
+    ) {
+
+        return null;
+    }
+
+    // 친구 추가 요청 거절
+    @PostMapping("/follows/{relationshipId}/reject")
+    public ResponseEntity<Void> rejectFriendRequest(
+            @PathVariable Long relationshipId
+    ) {
+
+        return null;
+    }
+
+    // 팔로우 목록 전체 조회
+    @GetMapping("/follows/followers")
+    public ResponseEntity<Relationship> getFollowers() {
+
+        return null;
+    }
+
+    // 팔로잉 목록 전체 조회
+    @GetMapping("/follows/following")
+    public ResponseEntity<Relationship> getFollowing() {
+
+        return null;
+    }
+
+    // 맞팔한 목록 전체 조회
+    @GetMapping("/follows/mutual")
+    public ResponseEntity<Relationship> getMutualFollowers() {
+
+        return null;
+    }
+
+    // 팔로우 취소
+    @DeleteMapping("/follows/{relationshipId}")
+    public ResponseEntity<Void> unfollow(
+            @PathVariable Long relationshipId
+    ) {
+
+        return null;
+    }
+
+    // 특정 유저 차단
+    @PostMapping("/blocks/{receiverId}")
+    public ResponseEntity<Relationship> block(
+            @PathVariable Long receiverId
+    ) {
+
+        return null;
+    }
+
+    // 차단 목록 전체 조회
+    @GetMapping("/blocks")
+    public ResponseEntity<Relationship> getBlockedMembers() {
+
+        return null;
+    }
+
+    // 특정 유저 차단 해제
+    @DeleteMapping("/blocks/{receiverId}")
+    public ResponseEntity<Void> unblock(
+            @PathVariable Long receiverId
+    ) {
+
+        return null;
+    }
+
+}

--- a/src/main/java/com/example/newsfeed/relationship/RelationshipController.java
+++ b/src/main/java/com/example/newsfeed/relationship/RelationshipController.java
@@ -17,8 +17,10 @@ public class RelationshipController {
     @PostMapping("/follows/{receiverId}/request")
     public ResponseEntity<FriendRequestResponseDto> sendFriendRequest(
             @PathVariable Long receiverId
+//            @SessionAttribute(name = Const.LOGIN_USER) Long senderId
     ) {
-        FriendRequestResponseDto response = relationshipService.sendFriendRequest(receiverId);
+        Long senderId = 1L; // 임시 사용자 id(나중에 세션으로 적용)
+        FriendRequestResponseDto response = relationshipService.sendFriendRequest(senderId, receiverId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/example/newsfeed/relationship/dto/FriendAcceptResponseDto.java
+++ b/src/main/java/com/example/newsfeed/relationship/dto/FriendAcceptResponseDto.java
@@ -1,0 +1,31 @@
+package com.example.newsfeed.relationship.dto;
+
+import com.example.newsfeed.relationship.entity.Relationship;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class FriendAcceptResponseDto {
+
+    private final Long id;
+    private final Long receiverId;
+    private final Long senderId;
+    private final LocalDateTime updatedAt;
+
+    public FriendAcceptResponseDto(Long id, Long receiverId, Long senderId, LocalDateTime updatedAt) {
+        this.id = id;
+        this.receiverId = receiverId;
+        this.senderId = senderId;
+        this.updatedAt = updatedAt;
+    }
+
+    public FriendAcceptResponseDto of(Relationship relationship) {
+        return new FriendAcceptResponseDto(
+                relationship.getId(),
+                relationship.getReceiverId(),
+                relationship.getSenderId(),
+                relationship.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/newsfeed/relationship/dto/FriendRequestResponseDto.java
+++ b/src/main/java/com/example/newsfeed/relationship/dto/FriendRequestResponseDto.java
@@ -1,0 +1,31 @@
+package com.example.newsfeed.relationship.dto;
+
+import com.example.newsfeed.relationship.entity.Relationship;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class FriendRequestResponseDto {
+
+    private final Long id;
+    private final Long receiverId;
+    private final Long senderId;
+    private final LocalDateTime createdAt;
+
+    public FriendRequestResponseDto(Long id, Long receiverId, Long senderId, LocalDateTime createdAt) {
+        this.id = id;
+        this.receiverId = receiverId;
+        this.senderId = senderId;
+        this.createdAt = createdAt;
+    }
+
+    public FriendRequestResponseDto of(Relationship relationship) {
+        return new FriendRequestResponseDto(
+                relationship.getId(),
+                relationship.getReceiverId(),
+                relationship.getSenderId(),
+                relationship.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/newsfeed/relationship/dto/FriendRequestResponseDto.java
+++ b/src/main/java/com/example/newsfeed/relationship/dto/FriendRequestResponseDto.java
@@ -20,7 +20,7 @@ public class FriendRequestResponseDto {
         this.createdAt = createdAt;
     }
 
-    public FriendRequestResponseDto of(Relationship relationship) {
+    public static FriendRequestResponseDto of(Relationship relationship) {
         return new FriendRequestResponseDto(
                 relationship.getId(),
                 relationship.getReceiverId(),

--- a/src/main/java/com/example/newsfeed/relationship/entity/Relationship.java
+++ b/src/main/java/com/example/newsfeed/relationship/entity/Relationship.java
@@ -1,0 +1,42 @@
+package com.example.newsfeed.relationship.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@Table(name = "relationship")
+public class Relationship {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "relationship_id")
+    private Long id;
+
+    // 임시 필드
+    @Column(name = "from_member_id")
+    private Long senderId;
+
+    @Column(name = "to_member_id")
+    private Long receiverId;
+
+    // 나중에 개발
+//    @ManyToOne
+//    @JoinColumn(name = "from_member_id")
+//    private Member sender;
+//
+//    @ManyToOne
+//    @JoinColumn(name = "to_member_id")
+//    private Member receiver;
+
+    @Enumerated(EnumType.STRING)
+    private RelationshipStatus status;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/newsfeed/relationship/entity/Relationship.java
+++ b/src/main/java/com/example/newsfeed/relationship/entity/Relationship.java
@@ -39,4 +39,13 @@ public class Relationship {
 
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    public Relationship(Long senderId, Long receiverId) {
+        this.senderId = senderId;
+        this.receiverId = receiverId;
+    }
+
+    public void updateStatus(RelationshipStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/example/newsfeed/relationship/entity/RelationshipStatus.java
+++ b/src/main/java/com/example/newsfeed/relationship/entity/RelationshipStatus.java
@@ -1,0 +1,7 @@
+package com.example.newsfeed.relationship.entity;
+
+public enum RelationshipStatus {
+    REQUESTED,   // 친구 요청
+    ACCEPTED,    // 친구 관계
+    BLOCKED      // 차단됨
+}

--- a/src/main/java/com/example/newsfeed/relationship/repository/RelationshipRepository.java
+++ b/src/main/java/com/example/newsfeed/relationship/repository/RelationshipRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RelationshipRepository extends JpaRepository<Relationship, Long> {
 
+    boolean existsBySenderIdAndReceiverId(Long senderId, Long receiverId);
 }

--- a/src/main/java/com/example/newsfeed/relationship/repository/RelationshipRepository.java
+++ b/src/main/java/com/example/newsfeed/relationship/repository/RelationshipRepository.java
@@ -1,0 +1,8 @@
+package com.example.newsfeed.relationship.repository;
+
+import com.example.newsfeed.relationship.entity.Relationship;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RelationshipRepository extends JpaRepository<Relationship, Long> {
+
+}

--- a/src/main/java/com/example/newsfeed/relationship/service/RelationshipService.java
+++ b/src/main/java/com/example/newsfeed/relationship/service/RelationshipService.java
@@ -1,0 +1,42 @@
+package com.example.newsfeed.relationship.service;
+
+import com.example.newsfeed.relationship.dto.FriendRequestResponseDto;
+import com.example.newsfeed.relationship.entity.Relationship;
+import com.example.newsfeed.relationship.repository.RelationshipRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RelationshipService {
+
+    private RelationshipRepository relationshipRepository;
+
+    public FriendRequestResponseDto sendFriendRequest(Long receiverId) {
+        return null;
+    }
+
+    public Relationship acceptFriendRequest(Long relationshipId) {
+        return null;
+    }
+
+    public Relationship getFollowers() {
+        return null;
+    }
+
+    public Relationship getFollowing() {
+        return null;
+    }
+
+    public Relationship getMutualFollowers() {
+        return null;
+    }
+    
+    public Relationship getBlockedMembers() {
+        return null;
+    }
+
+    public Relationship block(Long receiverId) {
+        return null;
+    }
+}

--- a/src/main/java/com/example/newsfeed/relationship/service/RelationshipService.java
+++ b/src/main/java/com/example/newsfeed/relationship/service/RelationshipService.java
@@ -2,18 +2,29 @@ package com.example.newsfeed.relationship.service;
 
 import com.example.newsfeed.relationship.dto.FriendRequestResponseDto;
 import com.example.newsfeed.relationship.entity.Relationship;
+import com.example.newsfeed.relationship.entity.RelationshipStatus;
 import com.example.newsfeed.relationship.repository.RelationshipRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class RelationshipService {
 
-    private RelationshipRepository relationshipRepository;
+    private final RelationshipRepository relationshipRepository;
 
-    public FriendRequestResponseDto sendFriendRequest(Long receiverId) {
-        return null;
+    @Transactional
+    public FriendRequestResponseDto sendFriendRequest(Long senderId, Long receiverId) {
+        if (relationshipRepository.existsBySenderIdAndReceiverId(senderId, receiverId)) {
+            throw new IllegalStateException("이미 친구 요청을 보냈습니다.");
+        }
+
+        Relationship relationship = new Relationship(senderId, receiverId);
+        relationship.updateStatus(RelationshipStatus.REQUESTED);
+        Relationship savedRelationship = relationshipRepository.save(relationship);
+        return FriendRequestResponseDto.of(savedRelationship);
     }
 
     public Relationship acceptFriendRequest(Long relationshipId) {
@@ -31,7 +42,7 @@ public class RelationshipService {
     public Relationship getMutualFollowers() {
         return null;
     }
-    
+
     public Relationship getBlockedMembers() {
         return null;
     }


### PR DESCRIPTION
## 📌 작업 내역
- [X] `Relationship` 엔티티와 각 Layer의 기본 골격 추가
- [X] 친구 추가 요청 기능 구현

## 🔨 변경 사항
- [X] `RelationshipController`에 `/follows/{receiverId}/request` API 추가
- [X] `RelationshipService`에 `sendFriendRequest()` 메서드 추가 
- [X] `RelationshipRepository`에 `existsBySenderIdAndReceiverId()` 메서드 추가

## ✅ 테스트 방법
1. 친구 추가 요청 API 호출 (`POST /follows/2/request`)
3. 데이터베이스에서 `relationship` 테이블에 정상적으로 저장되었는지 확인

## 📝 PR 특이사항

- 아직 로그인 기능이 없어 임시 필드로 Long 타입 id값 사용 중
- `BaseEntity`가 없어 `createdAt`과 `updatedAt` 필드는 null로 저장

![image](https://github.com/user-attachments/assets/4a9f1252-9985-4375-b087-9731b898d47a)

