### PR TITLE
feat(relationship): 언팔로우 및 차단 관련 기능 구현

### DIFF
--- a/src/main/java/com/example/newsfeed/relationship/controller/RelationshipController.java
+++ b/src/main/java/com/example/newsfeed/relationship/controller/RelationshipController.java
@@ -1,9 +1,9 @@
 package com.example.newsfeed.relationship.controller;
 
+import com.example.newsfeed.relationship.dto.BlockResponseDto;
 import com.example.newsfeed.relationship.dto.FollowResponseDto;
 import com.example.newsfeed.relationship.dto.FriendAcceptResponseDto;
 import com.example.newsfeed.relationship.dto.FriendRequestResponseDto;
-import com.example.newsfeed.relationship.entity.Relationship;
 import com.example.newsfeed.relationship.service.RelationshipService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -80,33 +80,43 @@ public class RelationshipController {
             @SessionAttribute(name = "token") Long memberId,
             @PathVariable Long targetId
     ) {
-        relationshipService.unfollow(4L, 2L);
+        relationshipService.unfollow(memberId, targetId);
         return ResponseEntity.ok().build();
     }
 
     // 특정 유저 차단
     @PostMapping("/blocks/{receiverId}")
-    public ResponseEntity<Relationship> block(
+    public ResponseEntity<BlockResponseDto> block(
+            @SessionAttribute(name = "token") Long memberId,
             @PathVariable Long receiverId
     ) {
-
-        return null;
+        BlockResponseDto response = relationshipService.block(memberId, receiverId);
+        return ResponseEntity.ok(response);
     }
 
     // 차단 목록 전체 조회
     @GetMapping("/blocks")
-    public ResponseEntity<Relationship> getBlockedMembers() {
+    public ResponseEntity<List<BlockResponseDto>> getBlockedMembers(
+            @SessionAttribute(name = "token") Long memberId
+    ) {
+        List<BlockResponseDto> response = relationshipService.getBlockedMembers(memberId);
 
-        return null;
+        // 차단된 사용자가 없을때
+        if (response.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+
+        return ResponseEntity.ok(response);
     }
 
     // 특정 유저 차단 해제
     @DeleteMapping("/blocks/{receiverId}")
     public ResponseEntity<Void> unblock(
+            @SessionAttribute(name = "token") Long memberId,
             @PathVariable Long receiverId
     ) {
-
-        return null;
+        relationshipService.unblock(memberId, receiverId);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/com/example/newsfeed/relationship/controller/RelationshipController.java
+++ b/src/main/java/com/example/newsfeed/relationship/controller/RelationshipController.java
@@ -75,12 +75,13 @@ public class RelationshipController {
     }
 
     // 팔로우 취소
-    @DeleteMapping("/follows/{relationshipId}")
+    @DeleteMapping("/follows/{targetId}")
     public ResponseEntity<Void> unfollow(
-            @PathVariable Long relationshipId
+            @SessionAttribute(name = "token") Long memberId,
+            @PathVariable Long targetId
     ) {
-
-        return null;
+        relationshipService.unfollow(4L, 2L);
+        return ResponseEntity.ok().build();
     }
 
     // 특정 유저 차단

--- a/src/main/java/com/example/newsfeed/relationship/dto/BlockResponseDto.java
+++ b/src/main/java/com/example/newsfeed/relationship/dto/BlockResponseDto.java
@@ -1,0 +1,37 @@
+package com.example.newsfeed.relationship.dto;
+
+import com.example.newsfeed.relationship.entity.Relationship;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class BlockResponseDto {
+
+    private final Long id;
+    private final Long senderId;
+    private final Long receiverId;
+    private final String status;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public BlockResponseDto(Long id, Long senderId, Long receiverId, String status, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.senderId = senderId;
+        this.receiverId = receiverId;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static BlockResponseDto of(Relationship relationship) {
+        return new BlockResponseDto(
+                relationship.getId(),
+                relationship.getSender().getId(),
+                relationship.getReceiver().getId(),
+                relationship.getStatus().name(),
+                relationship.getCreatedAt(),
+                relationship.getModifiedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/newsfeed/relationship/repository/RelationshipRepository.java
+++ b/src/main/java/com/example/newsfeed/relationship/repository/RelationshipRepository.java
@@ -5,6 +5,7 @@ import com.example.newsfeed.relationship.entity.RelationshipStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface RelationshipRepository extends JpaRepository<Relationship, Long> {
 
@@ -17,4 +18,6 @@ public interface RelationshipRepository extends JpaRepository<Relationship, Long
     List<Relationship> findByReceiverIdAndStatus(Long receiverId, RelationshipStatus status);
 
     List<Relationship> findBySenderIdAndStatus(Long senderId, RelationshipStatus status);
+
+    Optional<Relationship> findBySenderIdAndReceiverId(Long memberId, Long targetId);
 }


### PR DESCRIPTION
## 📌 작업 내역
- [X] 언팔로우 기능 구현
- [X] 차단 기능 구현
- [X] 차단 목록 조회 구현
- [X] 차단 해제 기능 구현

## 🔨 변경 사항
- [X] `RelationshipRepository`에 `findBySenderIdAndReceiverId()` 메서드 추가
- [X] 

## ✅ 테스트 방법
1. 차단 API 호출 (`POST /follows/blocks/2`)
2. 차단 목록 조회 API 호출 ('GET /blocks`)
3. 차단 해제 API 호출 ('DELETE /blocks/2`)
4. 데이터베이스에서 `relationship` 테이블에 정상적으로 저장되었는지 확인

## 📝 PR 특이사항
- 언팔로우 시 맞팔인 경우/나만 팔로우 중인 경우 분리
- 현재 세션 사용 중이지만 JWT로 변경 예정
- 차단 목록 조회 시 차단한 사용자가 없을 때 `204` 응답 반환