### PR TITLE
feat(post): 차단된 사용자 게시물 숨김 기능 구현

### DIFF
--- a/src/main/java/com/example/newsfeed/post/controller/PostController.java
+++ b/src/main/java/com/example/newsfeed/post/controller/PostController.java
@@ -55,6 +55,18 @@ public class PostController {
         return ResponseEntity.ok(postService.findAll());
     }
 
+    // 차단된 사용자 제외 게시글 조회
+    @GetMapping("/filtered")
+    public ResponseEntity<List<PostResponseDto>> findAllExcludingBlockedUsers(
+            @RequestHeader("Authorization") String token
+    ) {
+        String jwt = token.replace("Bearer","");
+        Long memberId = memberService.getMemberIdFromToken(jwt);
+        List<PostResponseDto> responseDtos = postService.findAllExcludingBlockedUsers(memberId);
+
+        return ResponseEntity.ok(responseDtos);
+    }
+
     //게시물 단건 조회
     @GetMapping("/{postId}")
     public ResponseEntity<PostResponseDto> findById(

--- a/src/main/java/com/example/newsfeed/post/dto/response/PostPageResponseDto.java
+++ b/src/main/java/com/example/newsfeed/post/dto/response/PostPageResponseDto.java
@@ -3,7 +3,6 @@ package com.example.newsfeed.post.dto.response;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Getter
 public class PostPageResponseDto {

--- a/src/main/java/com/example/newsfeed/post/dto/response/PostResponseDto.java
+++ b/src/main/java/com/example/newsfeed/post/dto/response/PostResponseDto.java
@@ -1,9 +1,8 @@
 package com.example.newsfeed.post.dto.response;
 
+import com.example.newsfeed.post.entity.Post;
 import com.example.newsfeed.post.entity.State;
 import lombok.Getter;
-
-import java.time.LocalDateTime;
 
 @Getter
 public class PostResponseDto {
@@ -32,5 +31,18 @@ public class PostResponseDto {
         this.state = state;
         this.likeCount = likeCount;
         this.commentCount = commentCount;
+    }
+
+    public static PostResponseDto of(Post post) {
+        return new PostResponseDto(
+                post.getPostId(),
+                post.getTitle(),
+                post.getMember().getName(),
+                post.getMediaUrl(),
+                post.getDescription(),
+                post.getState(),
+                post.getLikeCount(),
+                post.getCommentCount()
+        );
     }
 }

--- a/src/main/java/com/example/newsfeed/post/repository/PostRepository.java
+++ b/src/main/java/com/example/newsfeed/post/repository/PostRepository.java
@@ -4,8 +4,11 @@ import com.example.newsfeed.post.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post,Long> {
     Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);
@@ -15,4 +18,7 @@ public interface PostRepository extends JpaRepository<Post,Long> {
     Page<Post> findAllByOrderByLikeCountDesc(Pageable pageable);
 
     Page<Post> findByCreatedAtBetween( LocalDateTime startDate, LocalDateTime endDate,Pageable pageable);
+
+    @Query("SELECT p FROM Post p WHERE (:blockedMemberIds IS NULL OR p.member.id NOT IN :blockedMemberIds)")
+    List<Post> findAllExcludingBlockedUsers(@Param("blockedMemberIds") List<Long> blockedMemberIds);
 }

--- a/src/main/java/com/example/newsfeed/post/service/PostService.java
+++ b/src/main/java/com/example/newsfeed/post/service/PostService.java
@@ -4,21 +4,20 @@ import com.example.newsfeed.comment.repository.CommentRepository;
 import com.example.newsfeed.member.entity.Member;
 import com.example.newsfeed.member.repository.MemberRepository;
 import com.example.newsfeed.post.dto.request.PostPageRequestDto;
-import com.example.newsfeed.post.dto.request.PostStateChangeRequestDto;
-import com.example.newsfeed.post.dto.response.PostPageResponseDto;
 import com.example.newsfeed.post.dto.request.PostSaveRequestDto;
+import com.example.newsfeed.post.dto.request.PostStateChangeRequestDto;
+import com.example.newsfeed.post.dto.request.PostUpdateRequestDto;
+import com.example.newsfeed.post.dto.response.PostPageResponseDto;
 import com.example.newsfeed.post.dto.response.PostResponseDto;
 import com.example.newsfeed.post.dto.response.PostSaveResponseDto;
-import com.example.newsfeed.post.dto.request.PostUpdateRequestDto;
 import com.example.newsfeed.post.dto.response.PostUpdateResponseDto;
-import com.example.newsfeed.post.entity.MediaUrl;
 import com.example.newsfeed.post.entity.Post;
 import com.example.newsfeed.post.entity.State;
-import com.example.newsfeed.post.repository.MediaUrlRepository;
 import com.example.newsfeed.post.repository.PostRepository;
+import com.example.newsfeed.relationship.entity.RelationshipStatus;
+import com.example.newsfeed.relationship.repository.RelationshipRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -26,13 +25,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -42,6 +36,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
     private final CommentRepository commentRepository;
+    private final RelationshipRepository relationshipRepository;
     private final MediaUrlService mediaUrlService;
     private final State STATE_DELETE = State.DELETE;
 
@@ -90,6 +85,21 @@ public class PostService {
                         post.getLikeCount(),
                         commentRepository.countByPost(post)))
                 .collect(Collectors.toList());
+    }
+
+    public List<PostResponseDto> findAllExcludingBlockedUsers(Long memberId) {
+        List<Long> blockedMemberIds = relationshipRepository.findBySenderIdAndStatus(memberId, RelationshipStatus.BLOCKED)
+                .stream().map(r -> r.getReceiver().getId())
+                .toList();
+
+        // 차단한 사용자가 없을 경우 모든 게시물 반환
+        List<Post> posts = blockedMemberIds.isEmpty()
+                ? postRepository.findAll()
+                : postRepository.findAllExcludingBlockedUsers(blockedMemberIds);
+
+        return posts.stream()
+                .map(PostResponseDto::of)
+                .toList();
     }
 
     @Transactional

--- a/src/main/java/com/example/newsfeed/relationship/repository/RelationshipRepository.java
+++ b/src/main/java/com/example/newsfeed/relationship/repository/RelationshipRepository.java
@@ -20,4 +20,6 @@ public interface RelationshipRepository extends JpaRepository<Relationship, Long
     List<Relationship> findBySenderIdAndStatus(Long senderId, RelationshipStatus status);
 
     Optional<Relationship> findBySenderIdAndReceiverId(Long memberId, Long targetId);
+
+
 }


### PR DESCRIPTION
## 📌 작업 내역
- [X] 차단된 사용자 게시물 숨김 기능 구현
- [X] 관계가 있는 상태(ACCEPTED, REQUESTED)에서 차단 시 발생하는 오류 수정

## 🔨 변경 사항
- [X] `PostController` 클래스에 `findAllExcludingBlockedUsers()` 추가
- [X] `PostService` 클래스에 `findAllExcludingBlockedUsers()` 추가
- [X] `PostRepository` 인터페이스에 `findAllExcludingBlockedUsers()` 추가
- [X] `RelationshipService` 클래스 `block()`에서 이미 관계가 존재할 경우 새로운 관계를 만들지 않고 상태만 변경하도록 수정

## ✅ 테스트 방법
1. 게시물 전체 조회 API 호출 (`GET /posts`)
![image](https://github.com/user-attachments/assets/0dc55e89-adf8-439c-992f-670e2804a42c)

2. 게시물 차단 제외 조회 API 호출 (`GET /posts/filtered`)
- 차단한 사용자의 게시물밖에 없기 때문에 빈 리스트가 생성됨.
![image](https://github.com/user-attachments/assets/09489d14-063a-424d-91d1-31457144fde3)

## 📝 PR 특이사항
- 없음